### PR TITLE
Hiding Primary Column & Forwarding Interface Style Traits

### DIFF
--- a/TOSplitViewController/TOSplitViewController.h
+++ b/TOSplitViewController/TOSplitViewController.h
@@ -289,6 +289,8 @@ showSecondaryViewController:(UIViewController *)viewController
  */
 @property (nonatomic, assign) CGFloat separatorStatusBarClipWidth;
 
+@property (nonatomic, assign) BOOL primaryColumnIsHidden;
+
 /**
  * Create a new split view controller instance. Provide the view controllers, in order
  * from left to right.

--- a/TOSplitViewController/TOSplitViewController.h
+++ b/TOSplitViewController/TOSplitViewController.h
@@ -291,6 +291,9 @@ showSecondaryViewController:(UIViewController *)viewController
 
 @property (nonatomic, assign) BOOL primaryColumnIsHidden;
 
+/// The duration to use when animating the primary column collapse animation. Default: 250ms
+@property (nonatomic, assign) NSTimeInterval collapseAnimationDuration;
+
 /**
  * Create a new split view controller instance. Provide the view controllers, in order
  * from left to right.

--- a/TOSplitViewController/TOSplitViewController.m
+++ b/TOSplitViewController/TOSplitViewController.m
@@ -109,7 +109,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.view.backgroundColor = [UIColor systemBackgroundColor];
+    self.view.backgroundColor = [UIColor whiteColor];
 
     self.horizontalSizeClass = self.view.traitCollection.horizontalSizeClass;
     self.visibleViewControllers = [NSMutableArray arrayWithArray:self.viewControllers];
@@ -123,7 +123,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     NSMutableArray *separators = [NSMutableArray array];
     for (NSInteger i = 0; i < 2; i++) {
         UIView *view = [[UIView alloc] init];
-        view.backgroundColor = UIColor.separatorColor;
+        view.backgroundColor = [UIColor colorWithWhite:0.f alpha:0.12f];
         [separators addObject:view];
     }
     self.separatorViews = [NSArray arrayWithArray:separators];
@@ -586,12 +586,33 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 
         // Set the size classes for each controller
         UITraitCollection *horizontalSizeClassCompact = [UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact];
-        UITraitCollection *interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
+        
+        UITraitCollection *interfaceStyleFromSelf = nil;
+        
+        if (@available(iOS 13, *)) {
+           interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
+        }
 
-        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+        UITraitCollection *primaryTraitCollection = nil;
+        UITraitCollection *secondaryTraitCollection = nil;
+        
+        if (@available(iOS 13, *)) {
+            
+            primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+            
+            secondaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[secondaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+            
+        }
+        else {
+            
+            primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact]];
+            
+            secondaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[secondaryController.traitCollection, horizontalSizeClassCompact]];
+            
+        }
+        
         [self setOverrideTraitCollection:primaryTraitCollection forChildViewController:primaryController];
-
-        UITraitCollection *secondaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[secondaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+        
         [self setOverrideTraitCollection:secondaryTraitCollection forChildViewController:secondaryController];
 
         // Update the layout
@@ -613,9 +634,26 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
         detailController.view.frame = frame;
 
         UITraitCollection *horizontalSizeClassCompact = [UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact];
-        UITraitCollection *interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
+        
+        UITraitCollection *interfaceStyleFromSelf = nil;
+        
+        if (@available(iOS 13, *)) {
+           interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
+        }
 
-        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+        UITraitCollection *primaryTraitCollection = nil;
+        
+        if (@available(iOS 13, *)) {
+            
+            primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
+        
+        }
+        else {
+            
+            primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact]];
+        
+        }
+
         [self setOverrideTraitCollection:primaryTraitCollection forChildViewController:primaryController];
 
         [primaryController.view layoutIfNeeded];

--- a/TOSplitViewController/TOSplitViewController.m
+++ b/TOSplitViewController/TOSplitViewController.m
@@ -109,7 +109,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
 
     self.horizontalSizeClass = self.view.traitCollection.horizontalSizeClass;
     self.visibleViewControllers = [NSMutableArray arrayWithArray:self.viewControllers];
@@ -123,7 +123,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     NSMutableArray *separators = [NSMutableArray array];
     for (NSInteger i = 0; i < 2; i++) {
         UIView *view = [[UIView alloc] init];
-        view.backgroundColor = self.separatorStrokeColor;
+        view.backgroundColor = UIColor.separatorColor;
         [separators addObject:view];
     }
     self.separatorViews = [NSArray arrayWithArray:separators];
@@ -586,11 +586,12 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 
         // Set the size classes for each controller
         UITraitCollection *horizontalSizeClassCompact = [UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact];
+        UITraitCollection *interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
 
-        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact]];
+        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
         [self setOverrideTraitCollection:primaryTraitCollection forChildViewController:primaryController];
 
-        UITraitCollection *secondaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[secondaryController.traitCollection, horizontalSizeClassCompact]];
+        UITraitCollection *secondaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[secondaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
         [self setOverrideTraitCollection:secondaryTraitCollection forChildViewController:secondaryController];
 
         // Update the layout
@@ -612,8 +613,9 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
         detailController.view.frame = frame;
 
         UITraitCollection *horizontalSizeClassCompact = [UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact];
+        UITraitCollection *interfaceStyleFromSelf = [UITraitCollection traitCollectionWithUserInterfaceStyle:self.traitCollection.userInterfaceStyle];
 
-        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact]];
+        UITraitCollection *primaryTraitCollection = [UITraitCollection traitCollectionWithTraitsFromCollections:@[primaryController.traitCollection, horizontalSizeClassCompact, interfaceStyleFromSelf]];
         [self setOverrideTraitCollection:primaryTraitCollection forChildViewController:primaryController];
 
         [primaryController.view layoutIfNeeded];

--- a/TOSplitViewController/TOSplitViewController.m
+++ b/TOSplitViewController/TOSplitViewController.m
@@ -527,6 +527,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 - (void)layoutViewControllersForBoundsSize:(CGSize)size
 {
     NSInteger numberOfColumns = self.visibleViewControllers.count;
+    
     if (numberOfColumns == 0) {
         return;
     }
@@ -537,23 +538,27 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     UIViewController *primaryController = self.primaryViewController;
     UIViewController *secondaryController = self.secondaryViewController;
     UIViewController *detailController = self.detailViewController;
-
+    
     // Laying out three columns
     if (numberOfColumns == 3) {
         CGFloat idealPrimaryWidth = self.primaryColumnMinimumWidth;
         CGFloat idealSecondaryWidth = self.secondaryColumnMinimumWidth;
         CGFloat idealDetailWidth = self.detailColumnMinimumWidth;
+        
+        if (self.primaryColumnIsHidden == YES) {
+            idealPrimaryWidth = 0.f;
+        }
 
         // Work out the percentage width of each element
         CGFloat totalWidth = idealPrimaryWidth + idealSecondaryWidth + idealDetailWidth;
 
         // Update the frames for each controller
         frame.size = size;
-        frame.size.width = ceilf((idealPrimaryWidth / totalWidth) * size.width);
+        frame.size.width = MIN(ceilf((idealPrimaryWidth / totalWidth) * size.width), self.primaryColumnMaximumWidth);
         primaryController.view.frame = frame;
 
         frame.origin.x = CGRectGetMaxX(frame);
-        frame.size.width = ceilf((idealSecondaryWidth / totalWidth) * size.width);
+        frame.size.width = MIN(ceilf((idealSecondaryWidth / totalWidth) * size.width), self.secondaryColumnMaximumWidth);
         secondaryController.view.frame = frame;
 
         frame.origin.x = CGRectGetMaxX(frame);
@@ -578,7 +583,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
         CGFloat idealPrimaryWidth = (size.width * self.preferredPrimaryColumnWidthFraction);
         idealPrimaryWidth = MAX(self.primaryColumnMinimumWidth, idealPrimaryWidth);
         idealPrimaryWidth = MIN(self.primaryColumnMaximumWidth, idealPrimaryWidth);
-
+        
         frame.size = size;
         frame.size.width = floorf(idealPrimaryWidth);
         primaryController.view.frame = frame;
@@ -954,6 +959,15 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
 }
 
 #pragma mark - Accessors -
+
+- (void)setPrimaryColumnIsHidden:(BOOL)primaryColumnIsHidden {
+    
+    _primaryColumnIsHidden = primaryColumnIsHidden;
+    
+    [self layoutSplitViewControllerContentForSize:self.view.bounds.size];
+    
+}
+
 - (void)setDelegate:(id<TOSplitViewControllerDelegate>)delegate
 {
     if (delegate == _delegate) { return; }

--- a/TOSplitViewController/TOSplitViewController.m
+++ b/TOSplitViewController/TOSplitViewController.m
@@ -101,6 +101,8 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     _maximumNumberOfColumns = 3;
 
     _separatorStrokeColor = [UIColor colorWithWhite:0.75f alpha:1.0f];
+    
+    _collapseAnimationDuration = 0.25;
 }
 
 #pragma mark - View Lifecylce -
@@ -522,6 +524,23 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     [controller.view removeFromSuperview];
     [controller didMoveToParentViewController:nil];
     return controller;
+}
+
+- (void)layoutSplitViewControllerContentForSize:(CGSize)size animated:(BOOL)animated {
+    
+    if (animated && self.collapseAnimationDuration > 0) {
+        
+        [UIView animateWithDuration:self.collapseAnimationDuration animations:^{
+           
+            [self layoutSplitViewControllerContentForSize:size];
+            
+        }];
+        
+    }
+    else {
+        [self layoutSplitViewControllerContentForSize:size];
+    }
+    
 }
 
 - (void)layoutViewControllersForBoundsSize:(CGSize)size
@@ -964,7 +983,7 @@ NSString * const TOSplitViewControllerNotificationSplitViewControllerKey =
     
     _primaryColumnIsHidden = primaryColumnIsHidden;
     
-    [self layoutSplitViewControllerContentForSize:self.view.bounds.size];
+    [self layoutSplitViewControllerContentForSize:self.view.bounds.size animated:YES];
     
 }
 

--- a/TOSplitViewControllerExample.xcodeproj/project.pbxproj
+++ b/TOSplitViewControllerExample.xcodeproj/project.pbxproj
@@ -196,7 +196,7 @@
 				TargetAttributes = {
 					224719E21E791A5D000886F9 = {
 						CreatedOnToolsVersion = 8.2;
-						DevelopmentTeam = 6LF3GMKZAB;
+						DevelopmentTeam = XMJKJH96ZT;
 						ProvisioningStyle = Automatic;
 					};
 					22F7246C1E94C22200CE38A8 = {
@@ -212,6 +212,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -401,7 +402,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				DEVELOPMENT_TEAM = XMJKJH96ZT;
 				INFOPLIST_FILE = TOSplitViewControllerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -414,7 +415,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				DEVELOPMENT_TEAM = XMJKJH96ZT;
 				INFOPLIST_FILE = TOSplitViewControllerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/TOSplitViewControllerExample/AppDelegate.m
+++ b/TOSplitViewControllerExample/AppDelegate.m
@@ -34,6 +34,9 @@
     NSArray *controllers = @[primaryNavController, secondaryNavController, detailNavController];
     TOSplitViewController *splitViewController = [[TOSplitViewController alloc] initWithViewControllers:controllers];
     splitViewController.delegate = self;
+    
+    splitViewController.primaryColumnMaximumWidth = 298.f;
+    splitViewController.secondaryColumnMaximumWidth = 375.f;
 
     self.window.rootViewController = splitViewController;
     [self.window makeKeyAndVisible];

--- a/TOSplitViewControllerExample/DetailViewController.m
+++ b/TOSplitViewControllerExample/DetailViewController.m
@@ -24,10 +24,10 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
 
     self.label = [[UILabel alloc] initWithFrame:CGRectZero];
-    self.label.textColor = [UIColor colorWithWhite:0.75f alpha:1.0f];
+    self.label.textColor = [UIColor labelColor];
     self.label.text = self.labelText ? self.labelText : @"XD";
     self.label.font = [UIFont systemFontOfSize:120.0f weight:UIFontWeightMedium];
     self.label.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin

--- a/TOSplitViewControllerExample/DetailViewController.m
+++ b/TOSplitViewControllerExample/DetailViewController.m
@@ -24,10 +24,16 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.view.backgroundColor = [UIColor systemBackgroundColor];
+    
+    if (@available(iOS 13, *)) {
+        self.view.backgroundColor = UIColor.systemBackgroundColor;
+    }
+    else {
+        self.view.backgroundColor = UIColor.whiteColor;
+    }
 
     self.label = [[UILabel alloc] initWithFrame:CGRectZero];
-    self.label.textColor = [UIColor labelColor];
+    self.label.textColor = [UIColor blackColor];
     self.label.text = self.labelText ? self.labelText : @"XD";
     self.label.font = [UIFont systemFontOfSize:120.0f weight:UIFontWeightMedium];
     self.label.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin

--- a/TOSplitViewControllerExample/SecondaryViewController.m
+++ b/TOSplitViewControllerExample/SecondaryViewController.m
@@ -8,6 +8,7 @@
 
 #import "SecondaryViewController.h"
 #import "TOSplitViewController.h"
+#import "DetailViewController.h"
 
 @interface SecondaryViewController ()
 
@@ -37,6 +38,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Secondary";
+    
+    UIImage *image = [UIImage systemImageNamed:@"sidebar.left"];
+    
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(didTapSidebarButton:)];
+    
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -82,7 +88,18 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    DetailViewController *detailController = [[DetailViewController alloc] init];
+    UINavigationController *detailNavController = [[UINavigationController alloc] initWithRootViewController:detailController];
+    
+    [self.to_splitViewController to_showDetailViewController:detailNavController sender:self];
+}
 
+#pragma mark - Actions
+
+- (void)didTapSidebarButton:(UIBarButtonItem *)sender {
+    
+    self.to_splitViewController.primaryColumnIsHidden = !self.to_splitViewController.primaryColumnIsHidden;
+    
 }
 
 @end

--- a/TOSplitViewControllerExample/SecondaryViewController.m
+++ b/TOSplitViewControllerExample/SecondaryViewController.m
@@ -38,17 +38,32 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Secondary";
-    
-    UIImage *image = [UIImage systemImageNamed:@"sidebar.left"];
-    
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(didTapSidebarButton:)];
-    
+    self.navigationItem.leftItemsSupplementBackButton = YES;
 }
 
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
     NSLog(@"Secondary will appear");
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    
+    [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+    
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        
+        if (newCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+            UIImage *image = [UIImage systemImageNamed:@"sidebar.left"];
+            
+            self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(didTapSidebarButton:)];
+        }
+        else {
+            self.navigationItem.leftBarButtonItem = nil;
+        }
+        
+    } completion:nil];
+    
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath

--- a/TOSplitViewControllerExample/SecondaryViewController.m
+++ b/TOSplitViewControllerExample/SecondaryViewController.m
@@ -53,7 +53,7 @@
     
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         
-        if (newCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+        if (self.to_splitViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
             UIImage *image = [UIImage systemImageNamed:@"sidebar.left"];
             
             self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(didTapSidebarButton:)];

--- a/TOSplitViewControllerExample/SecondaryViewController.m
+++ b/TOSplitViewControllerExample/SecondaryViewController.m
@@ -54,9 +54,11 @@
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         
         if (self.to_splitViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+            
             UIImage *image = [UIImage systemImageNamed:@"sidebar.left"];
             
             self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(didTapSidebarButton:)];
+            
         }
         else {
             self.navigationItem.leftBarButtonItem = nil;


### PR DESCRIPTION
### Hiding Primary Column
Adds the following properties: 
- `primaryColumnIsHidden`
- `collapseAnimationDuration`

Example has been updated to include the above demonstration. 

### Trait Collection Overrides
When overriding the trait collections, the `userInterfaceStyle` is also appended to the composite trait collection. 

I have made some changes to the example with respect setting background colours using the new system colours for the demo. This may be undesirable and can be reverted via an additional commit if necessary. 